### PR TITLE
Update to compile against new rustc

### DIFF
--- a/src/ez_rpc.rs
+++ b/src/ez_rpc.rs
@@ -45,7 +45,7 @@ impl EzRpcClient {
     pub fn new(server_address : &str) -> std::old_io::IoResult<EzRpcClient> {
         use std::old_io::net::{ip, tcp};
 
-        let addr : ip::SocketAddr = std::str::FromStr::from_str(server_address).expect("bad server address");
+        let addr : ip::SocketAddr = std::str::FromStr::from_str(server_address).ok().expect("bad server address");
 
         let tcp = try!(tcp::TcpStream::connect(addr));
 
@@ -145,7 +145,7 @@ impl EzRpcServer {
         use std::old_io::net::{ip, tcp};
         use std::old_io::Listener;
 
-        let addr : ip::SocketAddr = std::str::FromStr::from_str(bind_address).expect("bad bind address");
+        let addr : ip::SocketAddr = std::str::FromStr::from_str(bind_address).ok().expect("bad bind address");
 
         let tcp_listener = try!(tcp::TcpListener::bind(addr));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 #![crate_name="capnp-rpc"]
 #![crate_type="lib"]
 
-#![feature(box_syntax, collections, core, io, std_misc)]
+#![feature(box_syntax, core, io, std_misc)]
 
 extern crate core;
 extern crate capnp;


### PR DESCRIPTION
This uses the new Result<> output from FromStr, and removes collections from features to allow compilation under new rustc.

As with the other pull request, you may want to wait on merging it until a new rustc nightly is produced so it tests properly on Travis.
