### PR TITLE
Allow ReaderOptions to be specified when running RPC

### DIFF
--- a/src/ez_rpc.rs
+++ b/src/ez_rpc.rs
@@ -24,7 +24,7 @@ use rpc_capnp::{message, return_};
 use std;
 use std::old_io::Acceptor;
 use std::collections::hash_map::HashMap;
-use capnp::{any_pointer, MessageBuilder, MallocMessageBuilder};
+use capnp::{any_pointer, MessageBuilder, MallocMessageBuilder, ReaderOptions};
 use capnp::capability::{ClientHook, FromClientHook, Server};
 use rpc::{RpcConnectionState, RpcEvent, SturdyRefRestorer};
 use capability::{LocalClient};
@@ -51,7 +51,7 @@ impl EzRpcClient {
 
         let connection_state = RpcConnectionState::new();
 
-        let chan = connection_state.run(tcp.clone(), tcp.clone(), ());
+        let chan = connection_state.run(tcp.clone(), tcp.clone(), (), *ReaderOptions::new().fail_fast(false));
 
         return Ok(EzRpcClient { rpc_chan : chan, tcp : tcp });
     }
@@ -182,7 +182,7 @@ impl std::old_io::Acceptor<()> for EzRpcServer {
         let tcp = try!(self.tcp_acceptor.accept());
         std::thread::Thread::spawn(move || {
             let connection_state = RpcConnectionState::new();
-            let _rpc_chan = connection_state.run(tcp.clone(), tcp, Restorer::new(sender2));
+            let _rpc_chan = connection_state.run(tcp.clone(), tcp, Restorer::new(sender2), *ReaderOptions::new().fail_fast(false));
         });
         Ok(())
     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -381,7 +381,7 @@ impl RpcConnectionState {
     }
 
     pub fn run<T : ::std::old_io::Reader + Send, U : ::std::old_io::Writer + Send, V : SturdyRefRestorer + Send>(
-        self, inpipe: T, outpipe: U, restorer : V)
+        self, inpipe: T, outpipe: U, restorer : V, opts : ReaderOptions)
          -> ::std::sync::mpsc::Sender<RpcEvent> {
 
         let (result_rpc_chan, port) = ::std::sync::mpsc::channel::<RpcEvent>();
@@ -393,7 +393,7 @@ impl RpcConnectionState {
                 loop {
                     match serialize::new_reader(
                         &mut r,
-                        *ReaderOptions::new().fail_fast(false)) {
+                        opts) {
                         Err(_e) => { listener_chan.send(RpcEvent::Shutdown).is_ok(); break; }
                         Ok(message) => {
                             listener_chan.send(RpcEvent::IncomingMessage(box message)).is_ok();


### PR DESCRIPTION
Allow ReaderOptions to be specified in custom implementations of RpcServer/Client, allowing for large RPC support.
