### PR TITLE
add rpc::Disconnector for clients to cleanly disconnect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,8 @@ impl <VatId> RpcSystem <VatId> {
         result
     }
 
+    /// Returns a `Disconnector` future that can be run to cleanly close the connection to this `RpcSystem`'s network.
+    /// You should get the `Disconnector` before you spawn the `RpcSystem`.
     pub fn get_disconnector(&self) -> rpc::Disconnector<VatId> {
         rpc::Disconnector::new(self.connection_state.clone())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,10 @@ impl <VatId> RpcSystem <VatId> {
         handle.add(tasks);
         result
     }
+
+    pub fn get_disconnector(&self) -> rpc::Disconnector<VatId> {
+        rpc::Disconnector::new(self.connection_state.clone())
+    }
 }
 
 impl <VatId> Future for RpcSystem<VatId> where VatId: 'static {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1525,6 +1525,7 @@ enum DisconnectorState
     Disconnected
 }
 
+/// A `Future` that can be run to disconnect an `RpcSystem`'s ConnectionState and wait for it to be closed.
 pub struct Disconnector<VatId> where VatId: 'static {
     connection_state: Rc<RefCell<Option<Rc<ConnectionState<VatId>>>>>,
     state:  DisconnectorState,


### PR DESCRIPTION
implement `Disconnector` future that can cleanly shutdown a client's `RpcSystem`.  Resolves #23. Example of usage [here](https://github.com/ian-p-cooke/capntls/blob/master/src/client.rs#L68).